### PR TITLE
Re-introduction of the use os.makedirs instead of os.system mkdir

### DIFF
--- a/soscleaner/soscleaner.py
+++ b/soscleaner/soscleaner.py
@@ -371,7 +371,7 @@ class SOSCleaner:
                                 'Data Source Appears To Be LZMA Encrypted Data - decompressing into %s', self.origin_path)
                             self.logger.info(
                                 'LZMA Hack - Creating %s', self.origin_path)
-                            os.system('mkdir %s' % self.origin_path)
+                            os.makedirs( self.origin_path, 0755 )
                             subprocess.Popen(
                                 ["tar", "-xJf", path, "-C", self.origin_path]).wait()
 


### PR DESCRIPTION
This was previously fixed, but commit b1ae349 merge re-introduced the old code
by accident.

bandit report:
----------------
>> Issue: [B605:start_process_with_a_shell] Starting a process with a shell, possible injection detected, security issue.
Severity: High   Confidence: High
Location: /usr/lib/python2.7/dist-packages/soscleaner.py:
                                 self.logger.info('LZMA Hack - Creating %s', self.origin_path)
                                 os.system('mkdir %s' % self.origin_path)
----------------

Fix: #145

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>