### PR TITLE
Add soscleaner.conf file, all options commented.

### DIFF
--- a/soscleaner.conf
+++ b/soscleaner.conf
@@ -1,0 +1,35 @@
+# If you find yourself having to use additional command line options a lot.
+# You can create a config file at /etc/soscleaner.conf to handle these default values for you.
+#
+# Note:
+# Please make sure the config file is own by root for both the UID & GID and
+# that permission is set to READ & WRITE for the user ONLY (0600/-rw-------).
+
+#[Default]
+# The loglevel to run at, default is 'info'
+#loglevel = debug
+
+# Domain to use for obfuscation
+#root_domain = example.com
+
+# Defaults to False, True suppresses output to stdout
+#quiet = True
+
+#[DomainConfig]
+# Additional domains to obfuscate
+#domains: example.com,foo.com,domain.com
+
+#[KeywordConfig]
+# Keywords to obfuscate
+#keywords: foo,bar,some,other,words
+
+# Keyword files to obfuscate
+#keyword_files: keywords.txt
+
+#[NetworkConfig]
+# Additional networks to obfuscate
+#networks: 172.16.0.0/16
+
+#[MacConfig]
+# True/False (defaults to True) - if False MAC obfuscation will not occur
+#obfuscate_macs = False


### PR DESCRIPTION
Everything is commented on purpose, since this file is optional.

This could serve as an example configuration file example.
Useful for dh_installexamples which install example files
into package build directories in debian.

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>